### PR TITLE
Add backend Dockerfile

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,0 +1,22 @@
+FROM python:3.11-slim
+
+# Install WeasyPrint system dependencies
+RUN apt-get update && apt-get install -y \
+    libpango-1.0-0 \
+    libgdk-pixbuf2.0-0 \
+    libcairo2 \
+    libffi-dev \
+    libjpeg-dev \
+    libpng-dev \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy backend files
+COPY res.py pdf_utils.py resume.html ./
+
+ENTRYPOINT ["uvicorn", "res:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- add Dockerfile.backend for running the FastAPI backend

## Testing
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6877c12011848323b2bbf6a5d51cf2f3