### PR TITLE
Add frontend Dockerfile

### DIFF
--- a/Frontend/Dockerfile
+++ b/Frontend/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20 AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- add Dockerfile in `Frontend` to build with Node and serve via nginx

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6877c38e39308323bdfa93fa9519787d