### PR TITLE
Add auth guard hook for protected pages

### DIFF
--- a/Frontend/src/components/Dashboard.tsx
+++ b/Frontend/src/components/Dashboard.tsx
@@ -3,8 +3,10 @@ import { Link } from 'react-router-dom';
 import { FileText, Plus, Calendar, Building, TrendingUp, Star, Eye } from 'lucide-react';
 import { api } from '../utils/api';
 import { Resume } from '../types/types';
+import { useRequireAuth } from '../utils/auth';
 
 const Dashboard: React.FC = () => {
+  useRequireAuth();
   const [resumes, setResumes] = useState<Resume[]>([]);
   const [loading, setLoading] = useState(true);
 

--- a/Frontend/src/components/ProfilePage.tsx
+++ b/Frontend/src/components/ProfilePage.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { User, Phone, Mail, Github, FileText, Plus, X, Save, Loader } from 'lucide-react';
+import { useRequireAuth } from '../utils/auth';
 
 interface UserProfile {
   id?: number;
@@ -12,6 +13,7 @@ interface UserProfile {
 const emptyProfile = { name: '', phone: '', email: '', github: '', resumes: [''] };
 
 const ProfilePage: React.FC = () => {
+  useRequireAuth();
   const [profiles, setProfiles] = useState<UserProfile[]>([]);
   const [activeProfileId, setActiveProfileId] = useState<number | null>(null);
   const [editingProfile, setEditingProfile] = useState<UserProfile | null>(null);

--- a/Frontend/src/components/ResumeOptimizer.tsx
+++ b/Frontend/src/components/ResumeOptimizer.tsx
@@ -3,6 +3,7 @@ import { FileText, Building, User, Briefcase, Zap, TrendingUp, CheckCircle, Plus
 import { api } from '../utils/api';
 import { Resume } from '../types/types';
 import { useNavigate } from 'react-router-dom';
+import { useRequireAuth } from '../utils/auth';
 
 interface OptimizationState {
   step: 'input' | 'generating' | 'preview' | 'scoring' | 'optimizing' | 'final';
@@ -24,6 +25,7 @@ interface UserProfile {
 }
 
 const ResumeOptimizer: React.FC = () => {
+  useRequireAuth();
   const navigate = useNavigate();
   const [formData, setFormData] = useState({
     companyName: '',

--- a/Frontend/src/components/ResumePreview.tsx
+++ b/Frontend/src/components/ResumePreview.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate, Link } from 'react-router-dom';
 import { ArrowLeft, FileText, Building, Calendar, TrendingUp, Download, Share2, Edit } from 'lucide-react';
 import { api } from '../utils/api';
 import { Resume } from '../types/types';
+import { useRequireAuth } from '../utils/auth';
 
 /* ─────────────────────────  StructuredResume  ───────────────────────── */
 function StructuredResume({ raw }: { raw: unknown }) {
@@ -109,6 +110,7 @@ function StructuredResume({ raw }: { raw: unknown }) {
 
 
 const ResumePreview: React.FC = () => {
+  useRequireAuth();
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const [resume, setResume] = useState<Resume | null>(null);

--- a/Frontend/src/utils/auth.ts
+++ b/Frontend/src/utils/auth.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+/**
+ * Redirects to the login page if no authentication token is present.
+ */
+export function useRequireAuth() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      navigate('/login');
+    }
+  }, [navigate]);
+}


### PR DESCRIPTION
## Summary
- add `useRequireAuth` hook to redirect to login if no token
- use the new hook in Dashboard, ProfilePage, ResumeOptimizer and ResumePreview

## Testing
- `npm run lint` *(fails: cannot find '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6877f442b2d483239fe0c568d3e34d9b