### PR TITLE
Add JWT auth header to frontend API

### DIFF
--- a/Frontend/src/utils/api.ts
+++ b/Frontend/src/utils/api.ts
@@ -35,7 +35,12 @@ export const api = {
 
   getResumes: async () => {
     // Fetch resumes from backend API
-    const response = await fetch(`${API_URL}/results`);
+    const token = localStorage.getItem('token');
+    const response = await fetch(`${API_URL}/results`, {
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    });
     if (!response.ok) {
       throw new Error('Failed to fetch resumes');
     }
@@ -45,7 +50,12 @@ export const api = {
 
   getResumeById: async (id: string) => {
     // Fetch resume by ID from backend API
-    const response = await fetch(`${API_URL}/resume/${id}`);
+    const token = localStorage.getItem('token');
+    const response = await fetch(`${API_URL}/resume/${id}`, {
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    });
     if (!response.ok) {
       throw new Error('Failed to fetch resume by ID');
     }
@@ -58,9 +68,13 @@ export const api = {
 
   generateResume: async (data: any) => {
     // Call backend API to generate resume
+    const token = localStorage.getItem('token');
     const response = await fetch(`${API_URL}/generate_resume`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
       body: JSON.stringify(data)
     });
     if (!response.ok) {
@@ -72,9 +86,13 @@ export const api = {
 
   checkATSScore: async (data: any) => {
     // Call backend API to evaluate ATS score
+    const token = localStorage.getItem('token');
     const response = await fetch(`${API_URL}/evaluate_ats`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
       body: JSON.stringify(data)
     });
     if (!response.ok) {
@@ -86,9 +104,13 @@ export const api = {
 
   optimizeResume: async (data: any) => {
     // Call backend API to optimize resume
+    const token = localStorage.getItem('token');
     const response = await fetch(`${API_URL}/optimize_resume`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
       body: JSON.stringify(data)
     });
     if (!response.ok) {
@@ -104,9 +126,13 @@ export const api = {
 
   saveSelectedResume: async (data : any) => {
     // Call backend API to save selected resume status
+    const token = localStorage.getItem('token');
     const response = await fetch(`${API_URL}/saveselectedresume`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
       body: JSON.stringify(data)
     });
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- include JWT auth header for all API calls after login/signup
- persist JWT from login and signup responses

## Testing
- `npm run lint` *(fails: no-unused-vars, no-explicit-any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6877f32d92848323bf75030f7ea2202e